### PR TITLE
Auto-unwrap options when accessing record fields.

### DIFF
--- a/test.ml
+++ b/test.ml
@@ -1,0 +1,17 @@
+
+type t = { a: int; b: t option};;
+let testoa (x:t option) = x.a;;
+let testb x = x.b;;
+let testbb x = x.b.b;;
+let testbba x = x.b.b.a;;
+
+
+let check (x,s) = Printf.printf "%s -- %b\n" s x;;
+
+check((None).a = None, "(None).a = None");;
+check((None).b = None, "(None).b = None");;
+check((Some {a=1; b=None}).a = Some(1), "(Some {a=1; b=None}).a = Some(1)");;
+check((Some {a=1; b=None}).b = None, "(Some {a=1; b=None}).b = None");;
+check(testbba {a=1; b=None} = None, "testbba {a=1; b=None} = None");;
+check(testbba {a=1; b=Some{a=2; b=None}} = None, "testbba {a=1; b=Some{a=2; b=None}} = None");;
+check(testbba {a=1; b=Some{a=2; b=Some{a=3; b=None}}} = Some(3), "testbba {a=1; b=Some{a=2; b=Some{a=3; b=None}}} = Some(3)");;


### PR DESCRIPTION
Extend the type checker to auto-unwrap options when accessing record fields.

**Example interactive session.**
```
./ocaml
# type t = { a: int; b: t option};;
type t = { a : int; b : t option; }

# let testoa (x:t option) = x.a;;
val testoa : t option -> int option = <fun>

# let testb x = x.b;;
val testb : t -> t option = <fun>

# let testbb x = x.b.b;;
val testbb : t -> t option = <fun>

# let testbba x = x.b.b.a;;
val testbba : t -> int option = <fun>
```

**Properties.**
- Every program typeable before this extension, is still typeable, and has the same type.
- No new operators.
- Double options are flattened when accessing an optional field of an optional value.
- Ad-hoc polymorphism, just as with record disambiguation in stock ocaml. This means that some local record accesses cannot be moved into generic functions.
 

**How to build.**
```
./configure --prefix `pwd`
make world install
```

**Tests.**
```
./ocaml test.ml
```
